### PR TITLE
Changed cdn from unpkg.com to cdn.jsdelivr.net

### DIFF
--- a/interlocked/index.html
+++ b/interlocked/index.html
@@ -8,15 +8,15 @@
 	<body>
 		<div id="info">
         </div>
-		<script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/three@0.167.1/examples/jsm/libs/lil-gui.module.min.js"></script>
 
 		<script type="importmap">
-		  {
-			"imports": {
-			  "three": "https://unpkg.com/three@0.167.1/build/three.module.js",
-			  "three/addons/": "https://unpkg.com/three@0.167.1/examples/jsm/"
-			}
+		{
+		  "imports": {
+		    "three": "https://cdn.jsdelivr.net/npm/three@0.167.1/build/three.module.js",
+		    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.167.1/examples/jsm/"
 		  }
+		}
 		</script>
 
 		<script type="module" src="main.js">


### PR DESCRIPTION
The unpkg.com cdn is currently down causing https://penchekrak.github.io/interlocked/ to crush.
So, I changed unpkg.com to cdn.jsdelivr.net. 
Whether "interlocked" with changed cdn is now working or not can be checked at a fork https://mishadobrits.github.io/penchekrak.github.io/interlocked/ 